### PR TITLE
Fix requirements.txt version specifiers for smooth installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy-2.2.6
-Pillow-11.3.0
+numpy==2.2.6
+Pillow==11.3.0


### PR DESCRIPTION
This PR fixes a minor issue in the **requirements.txt** file where the package versions used a hyphen (-) instead of the correct double equals (==) for version pinning.

This change ensures dependencies install correctly using `pip install -r requirements.txt.`